### PR TITLE
New validators creation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ class Scheme(marshmallow.Schema):
   id = marshmallow.fields.Int(required=True)
   name = marshmallow.fields.Str(required=True)
 
-scheme_validator = vaa.marshmallow(Scheme)
+SchemeValidator = vaa.marshmallow(Scheme)
 ```
 
 ## Validating data
@@ -36,7 +36,7 @@ scheme_validator = vaa.marshmallow(Scheme)
 All schemes adopted by va has the same interface:
 
 ```python
-scheme = scheme_validator({'id': '1', 'name': 'Oleg'})
+scheme = SchemeValidator({'id': '1', 'name': 'Oleg'})
 scheme.is_valid()  # True
 scheme.cleaned_data
 # {'name': 'Oleg', 'id': 1}

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ Supported validators:
 
 | validator | adapter |
 | --------- | ------- |
-| [Cerberus](http://docs.python-cerberus.org/en/stable/) | `va.cerberus` |
-| [Django Forms](https://docs.djangoproject.com/en/2.2/topics/forms/) | `va.django` |
-| [Marshmallow](https://marshmallow.readthedocs.io/en/stable/) | `va.marshmallow` |
-| [PySchemes](https://github.com/spy16/pyschemes) | `va.pyschemes` |
-| [Django REST Framework](https://www.django-rest-framework.org/) | `va.restframework` |
-| [WTForms](https://wtforms.readthedocs.io/en/stable/) | `va.wtforms` |
+| [Cerberus](http://docs.python-cerberus.org/en/stable/) | `vaa.cerberus` |
+| [Django Forms](https://docs.djangoproject.com/en/2.2/topics/forms/) | `vaa.django` |
+| [Marshmallow](https://marshmallow.readthedocs.io/en/stable/) | `vaa.marshmallow` |
+| [Pydantic](https://pydantic-docs.helpmanual.io/) | `vaa.pydantic` |
+| [PySchemes](https://github.com/spy16/pyschemes) | `vaa.pyschemes` |
+| [Django REST Framework](https://www.django-rest-framework.org/) | `vaa.restframework` |
+| [WTForms](https://wtforms.readthedocs.io/en/stable/) | `vaa.wtforms` |
 
 ```bash
 python3 -m pip install --user vaa
@@ -33,7 +34,7 @@ SchemeValidator = vaa.marshmallow(Scheme)
 
 ## Validating data
 
-All schemes adopted by va has the same interface:
+All schemes adopted by `vaa` has the same interface:
 
 ```python
 scheme = SchemeValidator({'id': '1', 'name': 'Oleg'})

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ import marshmallow
 import vaa
 
 
-@vaa.marshmallow
 class Scheme(marshmallow.Schema):
   id = marshmallow.fields.Int(required=True)
   name = marshmallow.fields.Str(required=True)
+
+scheme_validator = vaa.marshmallow(Scheme)
 ```
 
 ## Validating data
@@ -35,14 +36,14 @@ class Scheme(marshmallow.Schema):
 All schemes adopted by va has the same interface:
 
 ```python
-validator = Scheme({'id': '1', 'name': 'Oleg'})
-validator.is_valid()  # True
-validator.cleaned_data
+scheme = scheme_validator({'id': '1', 'name': 'Oleg'})
+scheme.is_valid()  # True
+scheme.cleaned_data
 # {'name': 'Oleg', 'id': 1}
 
-validator = Scheme({'id': 'no', 'name': 'Oleg'})
-validator.is_valid()  # False
-validator.errors
+scheme = Scheme({'id': 'no', 'name': 'Oleg'})
+scheme.is_valid()  # False
+scheme.errors
 # {'id': ['Not a valid integer.']}
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ validators = [
   "django",
   "djangorestframework",
   "marshmallow>=3.0.1",
+  "pydantic"
   "pyschemes",
   "wtforms",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ validators = [
   "django",
   "djangorestframework",
   "marshmallow>=3.0.1",
-  "pydantic"
+  "pydantic",
   "pyschemes",
   "wtforms",
 ]

--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -12,7 +12,7 @@ class Scheme(marshmallow.Schema):
 def test_valid():
     data = {'name': 'Gram', 'mail': 'master_fess@mail.ru', 'count': 10}
     v = Scheme(data)
-    assert v.is_valid() is True
+    assert v.is_valid is True
     assert v.cleaned_data == data
     assert v.errors is None
 
@@ -20,6 +20,6 @@ def test_valid():
 def test_invalid_name():
     data = {'name': 'Gram', 'mail': 'mail.ru', 'count': 10}
     v = Scheme(data)
-    assert v.is_valid() is False
+    assert v.is_valid is False
     assert v.cleaned_data is None
     assert v.errors == {'mail': ['Not a valid email address.']}

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -15,7 +15,7 @@ def test_valid(validator):
         'count': 20,
     }
     v = validator(data=data)
-    assert v.is_valid() is True
+    assert v.is_valid is True
     assert v.cleaned_data == data
 
 
@@ -26,7 +26,7 @@ def test_no_field(validator):
         'mail': 'test@example.ru',
     }
     v = validator(data=data)
-    assert v.is_valid() is False
+    assert v.is_valid is False
     assert v.errors
 
 
@@ -38,7 +38,7 @@ def test_invalid_int(validator):
         'count': 'lol',
     }
     v = validator(data=data)
-    assert v.is_valid() is False
+    assert v.is_valid is False
     assert v.errors
 
 
@@ -50,7 +50,7 @@ def test_types_converting(validator):
         'count': '10',
     }
     v = validator(request=True, data=data)
-    assert v.is_valid() is True
+    assert v.is_valid is True
     assert not v.errors
     assert 'count' in v.cleaned_data
     assert v.cleaned_data['count'] == 10
@@ -65,6 +65,6 @@ def test_explicit_keys(validator):
         'junk': 'test',
     }
     v = validator(request=True, data=data)
-    assert v.is_valid() is True
+    assert v.is_valid is True
     assert not v.errors
     assert 'junk' not in v.cleaned_data

--- a/tests/validators/post.py
+++ b/tests/validators/post.py
@@ -1,4 +1,5 @@
 import marshmallow
+import pydantic
 import pyschemes
 
 import vaa
@@ -10,6 +11,12 @@ class PostMarshmallow(marshmallow.Schema):
     count = marshmallow.fields.Int(required=True)
 
 
+class PostPydantic(pydantic.BaseModel):
+    name: str
+    mail: str
+    count: int
+
+
 post_pyschemes = pyschemes.Scheme({
     'name': str,
     'mail': str,
@@ -19,4 +26,5 @@ post_pyschemes = pyschemes.Scheme({
 postvalidators = [
     # vaa.marshmallow(PostMarshmallow),
     vaa.pyschemes(post_pyschemes),
+    vaa.pydantic(PostPydantic)
 ]

--- a/vaa/__init__.py
+++ b/vaa/__init__.py
@@ -3,13 +3,16 @@
 
 
 from ._aliases import (
-    cerberus,
-    django,
-    marshmallow,
-    pyschemes,
     simple,
-    restframework,
+)
+from ._external import (
     wtforms,
+    restframework,
+    pydantic,
+    pyschemes,
+    marshmallow,
+    django,
+    cerberus,
 )
 from ._internal import ValidationError
 

--- a/vaa/_aliases.py
+++ b/vaa/_aliases.py
@@ -1,9 +1,3 @@
-from . import _external, _internal
+from . import _internal
 
-cerberus = _external.Cerberus
-django = _external.Django
-marshmallow = _external.Marshmallow
-pyschemes = _external.PySchemes
-restframework = _external.RESTFramework
 simple = _internal.Simple
-wtforms = _external.WTForms

--- a/vaa/_external.py
+++ b/vaa/_external.py
@@ -153,17 +153,16 @@ def _format_pydantic_exc(exc):
 
 
 def pydantic(model, **kwargs) -> ValidatorType:
-    """Creates validator from Pydantic BaseModel"""
-    from pydantic import ValidationError
+    """Creates validator from Pydantic BaseModel
+    """
+    from pydantic import validate_model
 
-    def validate(data, **params) -> ValidationResult:
-        try:
-            cleaned_data = model(**data).dict(**params)
-            errors = None
-        except ValidationError as exc:
-            cleaned_data = None
+    def validate(data, **_) -> ValidationResult:
+        errors = None
+        cleaned_data, _, exc = validate_model(model, data, raise_exc=False)
+        if exc:
             errors = _format_pydantic_exc(exc)
+            cleaned_data = None
         return cleaned_data, errors, not errors
 
     return create_validator(model.__name__, validate, **kwargs)
-n


### PR DESCRIPTION
I found current wrappers concept a bit confusing and problematic to follow.

Instead of trying to copy validator class and add vaa api over it, I suggest to completely split them from each other.

So example from doc: 
```python
@vaa.marshmallow
class Scheme(marshmallow.Schema):
  id = marshmallow.fields.Int(required=True)
  name = marshmallow.fields.Str(required=True)

validator = Scheme({'id': '1', 'name': 'Oleg'})
validator.is_valid()  # True
validator.cleaned_data
# {'name': 'Oleg', 'id': 1}
```
Will look like this:
```python
class Scheme(marshmallow.Schema):
  id = marshmallow.fields.Int(required=True)
  name = marshmallow.fields.Str(required=True)

SchemeValidator = vaa.marshmallow(Scheme)  # make custom validator class for current scheme

scheme = SchemeValidator({'id': '1', 'name': 'Oleg'})
scheme.is_valid()  # True
scheme.cleaned_data
# {'name': 'Oleg', 'id': 1}
```

Also now validation is triggered on init of the validator (so cleaned_data or errors could be accessed right away) 
It keeps follow current api (none of tests were changed and all works just fine).
But if there any reasons to be triggered only by is_valid method, I can change it later

Also support for pydantic added
