### PR TITLE
Add `get_from` function

### DIFF
--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -1,0 +1,25 @@
+import pytest
+
+import vaa
+from .validators.post import postmodels
+from .validators.pre import premodels
+
+models = postmodels + premodels
+
+
+@pytest.mark.parametrize('model', models)
+def test_auto(model):
+    data = {
+        'name': 'Oleg',
+        'mail': 'test@example.ru',
+        'count': 20,
+    }
+    validator = vaa.get_from(model)
+    v = validator(data=data)
+    assert v.is_valid() is True
+    assert v.cleaned_data == data
+
+
+def test_wrong_model():
+    with pytest.raises(TypeError, match="No wrapper found for <class 'object'>."):
+        vaa.get_from(object)

--- a/tests/validators/post.py
+++ b/tests/validators/post.py
@@ -16,7 +16,12 @@ post_pyschemes = pyschemes.Scheme({
     'count': int,
 })
 
+postmodels = [
+    PostMarshmallow,
+    post_pyschemes,
+]
+
 postvalidators = [
-    # vaa.marshmallow(PostMarshmallow),
+    vaa.marshmallow(PostMarshmallow),
     vaa.pyschemes(post_pyschemes),
 ]

--- a/tests/validators/pre.py
+++ b/tests/validators/pre.py
@@ -36,6 +36,11 @@ scheme = dict(
 PreCerberus = cerberus.Validator(scheme, purge_unknown=True)
 
 
+premodels = [
+    PreWTForms,
+    PreCerberus,
+]
+
 prevalidators = [
     vaa.wtforms(PreWTForms),
     vaa.cerberus(PreCerberus),

--- a/vaa/__init__.py
+++ b/vaa/__init__.py
@@ -11,6 +11,7 @@ from ._aliases import (
     restframework,
     wtforms,
 )
+from ._auto import get_from
 from ._internal import ValidationError
 
 
@@ -19,6 +20,7 @@ __version__ = '0.1.4'
 __all__ = [
     'cerberus',
     'django',
+    'get_from',
     'marshmallow',
     'pyschemes',
     'restframework',

--- a/vaa/_auto.py
+++ b/vaa/_auto.py
@@ -1,0 +1,38 @@
+import importlib
+import logging
+
+from . import _external
+
+logger = logging.getLogger('vaa')
+
+SUPPORTED_VALIDATORS = {
+    'cerberus.Validator': _external.Cerberus,
+    'django.forms.Form': _external.Django,
+    'marshmallow.Schema': _external.Marshmallow,
+    'pyschemes.Scheme': _external.PySchemes,
+    'rest_framework.serializers.Serializer': _external.RESTFramework,
+    'wtforms.Form': _external.WTForms,
+}
+
+
+def get_from(validator):
+    for v, wrapper in available_validators.items():
+        if isinstance(validator, v) or (isinstance(validator, type) and issubclass(validator, v)):
+            return wrapper(validator)
+    raise TypeError(f'No wrapper found for {validator}.')
+
+
+def _get_available_validators():
+    for validator, wrapper in SUPPORTED_VALIDATORS.items():
+        try:
+            module, validator = validator.rsplit('.', 1)
+            module = importlib.import_module(module)
+            available_validators[getattr(module, validator)] = wrapper
+        except ImportError:
+            pass
+    logger.debug(f'Found {len(available_validators)} validators: {list(available_validators)}')
+
+
+if 'available_validators' not in globals():
+    available_validators = {}
+    _get_available_validators()


### PR DESCRIPTION
Added function which automatically finds needed validator for given structure

```py
import vaa
import marshmallow

class Scheme(marshmallow.Schema):
  id = marshmallow.fields.Int(required=True)
  name = marshmallow.fields.Str(required=True)

validator = vaa.get_from(Scheme)
v = validator(data=dict(id='2', name='John'))
```

